### PR TITLE
fix: 避免在输出 listing 时使用 `order = data` 对数据进行分组排序

### DIFF
--- a/src/tfl.md
+++ b/src/tfl.md
@@ -13,21 +13,6 @@ data l_7_3_1;
 run;
 ```
 
-## Listing 输出 RTF 使用 `order` 变量
-
-```sas
-column usubjid erlid dvseq dvterm dvstdtc dvreas dvsev dvacn dvres;
-define usubjid / order order = data "筛选号";
-define erlid   / order order = data "入组号";
-define dvseq   / "序号";
-define dvterm  / "偏离描述";
-define dvstdtc / "发生日期";
-define dvreas  / "发生原因";
-define dvsev   / "严重程度";
-define dvacn   / "纠正/预防措施";
-define dvres   / "结果";
-```
-
 ## @S 行内格式化
 
 ```sas


### PR DESCRIPTION
输出 listing 时，假设有 $A, B, C, D$ 四个分组变量，预期的逻辑应该是这样的：
1. 变量 $A$ 中先按照 $A_1, A_2, A_3, ...$ 排序，连续的 $A_i$ 只展示第一个值；
2. 在上一步中的每个 $A_i$ 中，变量 $B$ 按照 $B_1, B_2, B_3, ...$ 排序，连续的 $B_i$ 只展示第一个值；
3. 在上一步中的每个 $B_i$ 中，变量 $C$ 按照 $C_1, C_2, C_3, ...$ 排序，连续的 $C_i$ 只展示第一个值；
4. 在上一步中的每个 $C_i$ 中，变量 $D$ 按照 $D_1, D_2, D_3, ...$ 排序，连续的 $D_i$ 只展示第一个值；

然而，`order=data` 执行的逻辑如下：
1. 变量 $A$ 中先按照 $A_1, A_2, A_3, ...$ 排序，连续的 $A_i$ 只展示第一个值；
2. 在上一步的 $A_1$ 中，变量 $B$ 按照 $B_1, B_2, B_3, ...$ 排序，连续的 $B_i$ 只展示第一个值，此时变量 `B` 的排序会被记录下来；
3. 在上一步的 $B_1$ 中，变量 $C$ 按照 $C_1, C_2, C_3, ...$ 排序，连续的 $C_i$ 只展示第一个值，此时变量 `C` 的排序会被记录下来；
4. 在上一步的 $C_1$ 中，变量 $D$ 按照 $D_1, D_2, D_3, ...$ 排序，连续的 $D_i$ 只展示第一个值，此时变量 `D` 的排序会被记录下来；
5. 回到变量 $A$，开始在 $A_2$ 中对变量 $B$ 排序，但此时不会重新排序，而是尽可能沿用之前记录的排序结果。

步骤 5 导致了实际输出结果与预期不符。

举例说明：
若分组变量是 `arm`, `siteid`, `usubjid`，`arm` 有两个水平：`试验组` 和 `对照组`，`试验组` 包含的 `siteid` 有：`02`, `03`，`对照组` 包含的 `siteid` 有 `01`, `02`，如果使用 `order = data`，则在 `试验组` 中，`siteid` 的排序结果是 `02`, `03`，轮到 `对照组` 中排序时，首先会将 `02` 排在前面，然后再排剩余的 `siteid`，所以最终呈现的结果会是这样的：
```
arm   siteid usubjid
试验组 02    02001
            02002
            02005
      03    03001
      03    03002
对照组 02    02003
            02004
      01    01001
```

解决方案：参考这段代码，抛弃 `order` 选项，直接使用 `first.` 配合 `norsorted` 在将数据集传递给 ODS 前手动分组排序。
https://github.com/smjc-org/cheatlist/blob/8adf29675ae5ce47506c85c3f2bf8373605fa82c/src/tfl.md?plain=1#L3-L14